### PR TITLE
getTreatments(): get the treatment names from an assignment object serverside

### DIFF
--- a/admin/util.html
+++ b/admin/util.html
@@ -24,7 +24,7 @@
 <template name="tsAdminGroupInfo">
     <dl class="dl-horizontal ts-compact">
         <dt>Group:</dt>
-        <dd>{{_id}}</dd>
+        <dd>{{_id}} {{> tsAdminExpButtons}}</dd>
         <dt>Treatments:</dt>
         <dd>
             {{#each treatments}}

--- a/server/assignment.js
+++ b/server/assignment.js
@@ -169,6 +169,13 @@ class Assignment {
       });
     }
   }
+  /**
+   * @summary Retrieve the set of treatments that were added to this assignment.
+   * @returns {Array} Array of Treatment names.
+   */
+  getTreatments() {
+    return this._data().treatments;
+  }
 
   /**
    * @summary Send this user to the exit survey. User must be in the lobby.

--- a/server/assignment.js
+++ b/server/assignment.js
@@ -174,7 +174,7 @@ class Assignment {
    * @returns {Array} Array of Treatment names.
    */
   getTreatments() {
-    return this._data().treatments;
+    return this._data().treatments || [];
   }
 
   /**


### PR DESCRIPTION
I needed to have access to the treatments of the different assignments during the initialization of an instance:

e.g.:
```javascript
TurkServer.Instance.initialize(function () {
        //should only be two users, check the treatments of each user and record which one is blind
        var blindUserId = -1;
        var sightedAssistantId = -1;
        var users = this.instance.users();
        for (var i=0; i<users.length; i++){
            var userId = users[i];
            var assignment = TurkServer.Assignment.getCurrentUserAssignment(userId);
            var treatments = assignment.getTreatments();
            if(treatments.indexOf("blind_treatment") != -1) {
                blindUserId = userId
            }else{
                sightedAssistantId = userId;
            }
        }
}
```