### PR TITLE
Fix tests for Meteor 1.4

### DIFF
--- a/package.js
+++ b/package.js
@@ -30,7 +30,6 @@ Package.onUse(function (api) {
     'check',
     'deps',
     'ejson',
-    'stylus',
     'jquery',
     'random',
     'underscore',
@@ -38,6 +37,12 @@ Package.onUse(function (api) {
     'ecmascript',
     'facts'
   ]);
+
+  // Meteor 1.4 fixes
+  // Builds were breaking on Meteor 1.4 due to an older version of npm-bcrypt.
+  // This should work again, and not break on older versions.
+  api.use("npm-bcrypt@0.9.0");
+  api.use("stylus@2.513.4");
 
   api.use(["ddp", "mongo"]); // For pub/sub and collections
 

--- a/server/config.js
+++ b/server/config.js
@@ -11,7 +11,7 @@ const defaultPublicSettings = {
 const defaultSettings = {
   adminPassword: undefined,
   hits: {
-    acceptUnknownHits: true
+    acceptUnknownHits: false
   },
   experiment: {
     limit: {

--- a/tests/auth_tests.coffee
+++ b/tests/auth_tests.coffee
@@ -64,6 +64,8 @@ Tinytest.add "auth - with first time hit assignment", withCleanup (test) ->
   test.equal(record.workerId, workerId, "workerId not saved")
   test.equal(record.batchId, authBatchId)
 
+# Note: this test will work correctly only if acceptUnknownBatch === false in
+# config, or if the batch exists and is inactive.
 Tinytest.add "auth - reject incorrect batch", withCleanup (test) ->
   testFunc = -> TestUtils.authenticateWorker
     batchId: otherBatchId


### PR DESCRIPTION
This allows the package to load correctly and run on Meteor 1.4 (including after some changes made with @ElliotSalisbury).

However, it's not clear that it's backwards compatible with older versions of Meteor, so we'll either need to test before merging or failing that, just support newer versions.
