### PR TITLE
Bump the version for meteor related packages

### DIFF
--- a/package.js
+++ b/package.js
@@ -12,7 +12,7 @@ Npm.depends({
 });
 
 Package.onUse(function (api) {
-  api.versionsFrom("1.2.0.1");
+  api.versionsFrom("1.4.1.2");
 
   // Client-only deps
   api.use([


### PR DESCRIPTION
Old version 1.2.0.1 packages for meteor will no longer compile with new versions of meteor & node. The old version resolves to accounts-password@1.1.7 which pulls in npm-bcrypt@=0.7.8 which will not compile with node@>0.12.

To reproduce, get new versions of node (> 0.x), meteor (1.4). Then follow the current instructions in the README to install. The following error will result: 

```
 => Errors while adding packages:             

While loading package npm-bcrypt@0.7.8_2:
error: Command failed:
/home/cqz/.meteor/packages/meteor-tool/.1.4.1_2.1u74185++os.linux.x86_64+web.browser+web.cordova/mt-os.linux.x86_64/dev_bundle/bin/npm
rebuild --no-bin-links --update-binary
../src/bcrypt_node.cc: In destructor ‘virtual {anonymous}::baton_base::~baton_base()’:
../src/bcrypt_node.cc:54:18: error: ‘class v8::Persistent<v8::Function>’ has no member named
‘Dispose’
callback.Dispose();
^~~~~~~
../src/bcrypt_node.cc: At global scope:
../src/bcrypt_node.cc:128:19: error: variable or field ‘GenSaltAsync’ declared void
void GenSaltAsync(uv_work_t* req) {
^~~~~~~~~
../src/bcrypt_node.cc:128:19: error: ‘uv_work_t’ was not declared in this scope
../src/bcrypt_node.cc:128:30: error: ‘req’ was not declared in this scope
void GenSaltAsync(uv_work_t* req) {
^~~
../src/bcrypt_node.cc:137:24: error: variable or field ‘GenSaltAsyncAfter’ declared void
void GenSaltAsyncAfter(uv_work_t* req) {
^~~~~~~~~
../src/bcrypt_node.cc:137:24: error: ‘uv_work_t’ was not declared in this scope
../src/bcrypt_node.cc:137:35: error: ‘req’ was not declared in this scope
void GenSaltAsyncAfter(uv_work_t* req) {
^~~
../src/bcrypt_node.cc:429:30: error: expected ‘}’ at end of input
NODE_MODULE(bcrypt_lib, init);
^
../src/bcrypt_node.cc:80:6: warning: ‘bool {anonymous}::ValidateSalt(const char*)’ defined but
not used [-Wunused-function]
bool ValidateSalt(const char* salt) {
^~~~~~~~~~~~
make: *** [Release/obj.target/bcrypt_lib/src/bcrypt_node.o] Error 1
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit
(/home/cqz/.meteor/packages/meteor-tool/.1.4.1_2.1u74185++os.linux.x86_64+web.browser+web.cordova/mt-os.linux.x86_64/dev_bundle/lib/node_modules/node-gyp/lib/build.js:276:23)
gyp ERR! stack     at emitTwo (events.js:87:13)
gyp ERR! stack     at ChildProcess.emit (events.js:172:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
gyp ERR! System Linux 4.7.2-201.fc24.x86_64
gyp ERR! command
"/home/cqz/.meteor/packages/meteor-tool/.1.4.1_2.1u74185++os.linux.x86_64+web.browser+web.cordova/mt-os.linux.x86_64/dev_bundle/bin/node"
"/home/cqz/.meteor/packages/meteor-tool/.1.4.1_2.1u74185++os.linux.x86_64+web.browser+web.cordova/mt-os.linux.x86_64/dev_bundle/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js"
"rebuild"
gyp ERR! cwd
/home/cqz/.meteor/packages/npm-bcrypt/.0.7.8_2.y9doo8++os.linux.x86_64+web.browser+web.cordova/npm/node_modules/.temp-1wj8uuk/node_modules/bcrypt
gyp ERR! node -v v4.6.0
gyp ERR! node-gyp -v v3.4.0
gyp ERR! not ok 

npm ERR! Linux 4.7.2-201.fc24.x86_64
npm ERR! argv
"/home/cqz/.meteor/packages/meteor-tool/.1.4.1_2.1u74185++os.linux.x86_64+web.browser+web.cordova/mt-os.linux.x86_64/dev_bundle/bin/node"
"/home/cqz/.meteor/packages/meteor-tool/.1.4.1_2.1u74185++os.linux.x86_64+web.browser+web.cordova/mt-os.linux.x86_64/dev_bundle/bin/npm"
"rebuild" "--no-bin-links" "--update-binary"
npm ERR! node v4.6.0
npm ERR! npm  v3.10.8
npm ERR! code ELIFECYCLE
npm ERR! bcrypt@0.7.8 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the bcrypt@0.7.8 install script 'node-gyp rebuild'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the bcrypt package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-gyp rebuild
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs bcrypt
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls bcrypt
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!
/home/cqz/.meteor/packages/npm-bcrypt/.0.7.8_2.y9doo8++os.linux.x86_64+web.browser+web.cordova/npm/node_modules/.temp-1wj8uuk/npm-debug.log
../src/bcrypt_node.cc: In destructor ‘virtual {anonymous}::baton_base::~baton_base()’:
../src/bcrypt_node.cc:54:18: error: ‘class v8::Persistent<v8::Function>’ has no member named
‘Dispose’
callback.Dispose();
^~~~~~~
../src/bcrypt_node.cc: At global scope:
../src/bcrypt_node.cc:128:19: error: variable or field ‘GenSaltAsync’ declared void
void GenSaltAsync(uv_work_t* req) {
^~~~~~~~~
../src/bcrypt_node.cc:128:19: error: ‘uv_work_t’ was not declared in this scope
../src/bcrypt_node.cc:128:30: error: ‘req’ was not declared in this scope
void GenSaltAsync(uv_work_t* req) {
^~~
../src/bcrypt_node.cc:137:24: error: variable or field ‘GenSaltAsyncAfter’ declared void
void GenSaltAsyncAfter(uv_work_t* req) {
^~~~~~~~~
../src/bcrypt_node.cc:137:24: error: ‘uv_work_t’ was not declared in this scope
../src/bcrypt_node.cc:137:35: error: ‘req’ was not declared in this scope
void GenSaltAsyncAfter(uv_work_t* req) {
^~~
../src/bcrypt_node.cc:429:30: error: expected ‘}’ at end of input
NODE_MODULE(bcrypt_lib, init);
^
../src/bcrypt_node.cc:80:6: warning: ‘bool {anonymous}::ValidateSalt(const char*)’ defined but
not used [-Wunused-function]
bool ValidateSalt(const char* salt) {
^~~~~~~~~~~~
make: *** [Release/obj.target/bcrypt_lib/src/bcrypt_node.o] Error 1
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit
(/home/cqz/.meteor/packages/meteor-tool/.1.4.1_2.1u74185++os.linux.x86_64+web.browser+web.cordova/mt-os.linux.x86_64/dev_bundle/lib/node_modules/node-gyp/lib/build.js:276:23)
gyp ERR! stack     at emitTwo (events.js:87:13)
gyp ERR! stack     at ChildProcess.emit (events.js:172:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
gyp ERR! System Linux 4.7.2-201.fc24.x86_64
gyp ERR! command
"/home/cqz/.meteor/packages/meteor-tool/.1.4.1_2.1u74185++os.linux.x86_64+web.browser+web.cordova/mt-os.linux.x86_64/dev_bundle/bin/node"
"/home/cqz/.meteor/packages/meteor-tool/.1.4.1_2.1u74185++os.linux.x86_64+web.browser+web.cordova/mt-os.linux.x86_64/dev_bundle/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js"
"rebuild"
gyp ERR! cwd
/home/cqz/.meteor/packages/npm-bcrypt/.0.7.8_2.y9doo8++os.linux.x86_64+web.browser+web.cordova/npm/node_modules/.temp-1wj8uuk/node_modules/bcrypt
gyp ERR! node -v v4.6.0
gyp ERR! node-gyp -v v3.4.0
gyp ERR! not ok 

npm ERR! Linux 4.7.2-201.fc24.x86_64
npm ERR! argv
"/home/cqz/.meteor/packages/meteor-tool/.1.4.1_2.1u74185++os.linux.x86_64+web.browser+web.cordova/mt-os.linux.x86_64/dev_bundle/bin/node"
"/home/cqz/.meteor/packages/meteor-tool/.1.4.1_2.1u74185++os.linux.x86_64+web.browser+web.cordova/mt-os.linux.x86_64/dev_bundle/bin/npm"
"rebuild" "--no-bin-links" "--update-binary"
npm ERR! node v4.6.0
npm ERR! npm  v3.10.8
npm ERR! code ELIFECYCLE
npm ERR! bcrypt@0.7.8 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the bcrypt@0.7.8 install script 'node-gyp rebuild'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the bcrypt package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-gyp rebuild
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs bcrypt
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls bcrypt
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!
```
