### PR TITLE
Refresh assignment continues on exceptions

### DIFF
--- a/admin/admin.coffee
+++ b/admin/admin.coffee
@@ -422,7 +422,11 @@ Meteor.methods
     TurkServer.checkAdmin()
     check(batchId, String)
 
-    err = undefined
+    # We may encounter more than one error when refreshing a bunch of
+    # assignments. This allows things to continue as much as possible, but
+    # will throw the first error encountered.
+    err = null
+
     Assignments.find({
       batchId: batchId
       status: "completed"
@@ -433,9 +437,10 @@ Meteor.methods
       try
         asst.refreshStatus()
       catch e
-        err = e
+        err ?= e
 
-    return err
+    throw err if err?
+    return
 
   "ts-admin-refresh-assignment": (asstId) ->
     TurkServer.checkAdmin()

--- a/admin/admin.coffee
+++ b/admin/admin.coffee
@@ -422,6 +422,7 @@ Meteor.methods
     TurkServer.checkAdmin()
     check(batchId, String)
 
+    err = undefined
     Assignments.find({
       batchId: batchId
       status: "completed"
@@ -429,9 +430,12 @@ Meteor.methods
     }).forEach (a) ->
       asst = TurkServer.Assignment.getAssignment(a._id)
       # Refresh submitted assignments as they may have been auto-approved
-      asst.refreshStatus()
+      try
+        asst.refreshStatus()
+      catch e
+        err = e
 
-    return
+    return err
 
   "ts-admin-refresh-assignment": (asstId) ->
     TurkServer.checkAdmin()

--- a/server/assignment.js
+++ b/server/assignment.js
@@ -332,6 +332,8 @@ class Assignment {
       });
     } catch (e) {
       // XXX this is a bit hacky and will break if the exact error message changes
+      // Moreover, it will remove assignment records if run *LONG AFTER*
+      // MTurk no longer has kept track of an assignment.
       if ( e.toString().indexOf("does not exist") >= 0 ) {
         Meteor._debug(`${this.asstId} seems to have been returned on MTurk.`);        
         this.setReturned();


### PR DESCRIPTION
@josephcc suggested this a while ago; we should probably make this a little robust when handling errors (e.g. when assignments are in an erroneous state: #56).