### PR TITLE
Compatibility with new meteor + mturk versions

### DIFF
--- a/package.js
+++ b/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Npm.depends({
-  "mturk-api": "1.3.2",
+  "api-mturk": "1.2.4",
   jspath: "0.3.2",
   deepmerge: "0.2.7" // For merging config parameters
 });

--- a/server/mturk.js
+++ b/server/mturk.js
@@ -1,4 +1,4 @@
-const mturk = Npm.require('mturk-api');
+const mturk = Npm.require('api-mturk');
 const JSPath = Npm.require('jspath');
 
 let api = undefined;
@@ -13,7 +13,7 @@ if ( !TurkServer.config.mturk.accessKeyId ||
     sandbox: TurkServer.config.mturk.sandbox
   };
 
-  const promise = mturk.connect(config)
+  const promise = mturk.createClient(config)
     .then((api) => api)
     .catch(console.error);
   api = Promise.resolve(promise).await();


### PR DESCRIPTION
This PR just tracks some of the changes I played with to get turkserver-meteor working with the new mturk api (unsuccessfully). I'll note here a few other things that need to additionally change for compatibility with the latest Meteor version (currently 1.8):

- [ ] Swap Iron Router for Flow Router
- [ ] Update stylus version and import syntax
